### PR TITLE
Remove CAT temp directory after use

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import subprocess
 import yaml
+import shutil
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -88,6 +89,12 @@ def attach(req: AttachRequest):
         except OSError as e:
             raise HTTPException(status_code=500, detail=f"Failed reading {fname}: {e}")
         all_results.append({"filename": fname, "xyz": txt})
+
+    # Cleanup temporary directory after collecting results
+    try:
+        shutil.rmtree(tmpdir)
+    except OSError as e:
+        print(f"Warning: failed to remove temp directory {tmpdir}: {e}")
 
     return {"results": all_results, "message": f"CAT generated {len(all_results)} structure(s)"}
 


### PR DESCRIPTION
## Summary
- clean up after running `init_cat`
- avoid leaving temporary directories

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684065ec74508325abbc54329f1e0df4